### PR TITLE
Fixed the rsync error: some files/attrs were not transferred

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,4 +26,4 @@ jobs:
         run: ls -lah
 
       - name: Deploy with rsync
-        run: rsync -avzrP ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:repos/eatba/food-order-backend
+        run: rsync -rltDvzP ./ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:repos/eatba/food-order-backend


### PR DESCRIPTION
I got the following errors in github auto deployment task:
```
rsync: chgrp "/home/***/repos/eatba/food-order-backend/db/data" failed: Operation not permitted (1)
rsync: chgrp "/home/***/repos/eatba/food-order-backend/db/data/queries" failed: Operation not permitted (1)
```
So I used an answer from here to solve the problem: https://unix.stackexchange.com/a/532192

Options here:
 -r, --recursive recurse into directories

-l, --links copy symlinks as symlinks

-t, --times preserve modification times

-D preserve device files (super-user only) and preserve special files

-v verbose (show detailed logs)

-z compress data during transfer

-P , equivalent to --partial --progress . When this option is used, rsync shows a progress bar during the transfer and keeps the partially transferred files. It is useful when transferring large files over slow or unstable network connections