### PR TITLE
Fixed encoding error (亂碼)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,8 @@
+# in case of using docker compose the host will be
+# mysql-db, as defined in docker-compose.yml
+MYSQL_HOST="localhost"
+
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=quickOrder
+MYSQL_USER=someuser
+MYSQL_PASSWORD=somepassword1234

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ If you're running docker it's done like this:
 * `mysql -h localhost -u someuser -p < comment.sql`
 * `mysql -h localhost -u someuser -p < itemComment.sql`
 
+Also make sure your database is running with utf8mb4 encoding, otherwise Chinese will not render, an SQL command to check the encoding is:
+```show variables like 'char%'; show variables like 'collation%';```
+The encoding for the docker container of the database is set up in **db/Dockerfile** file
 ------------
 ### Running the project on a host machine
 First install the needed dependencies:

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,3 @@
+FROM mariadb:10.5.8
+
+COPY character-set.cnf /etc/mysql/conf.d/

--- a/db/character-set.cnf
+++ b/db/character-set.cnf
@@ -1,0 +1,11 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
+[mysqld]
+character-set-client-handshake = FALSE
+collation-server = utf8mb4_unicode_ci
+init-connect = 'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci'
+character-set-server = utf8mb4

--- a/db/data/queries/createTable.sql
+++ b/db/data/queries/createTable.sql
@@ -1,4 +1,4 @@
-ALTER DATABASE `quickOrder` COLLATE = `utf8_general_ci`;
+ALTER DATABASE `quickOrder` COLLATE = `utf8mb4_unicode_ci`;
 USE `quickOrder`;
 CREATE TABLE `Item` (
     `id` VARCHAR(20) NOT NULL PRIMARY KEY,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   mysql-db:
     env_file:
       - ".env"
-    image: "mariadb:10.5.8"
+    build: db
     command:
       - --default-authentication-plugin=mysql_native_password
     volumes:


### PR DESCRIPTION
## Source of bug
With Maria DB official docker image only **character_set_database** and **character_set_server** were set to **utf8mb**, but the other encoding wasn't
<img width="467" alt="Screen Shot 2022-05-14 at 6 03 11 PM" src="https://user-images.githubusercontent.com/49668442/168423513-fa58399a-13e7-4093-881d-cd1c5eca9bf1.png">
Hence when I checked the data **within the termina**l it would show the **correct** Chinese **characters** with the correct encoding, but when **node.js** accessed the database it would **receive** **gibberish** in latin

You can read what each of this character_set mean here in the official mariadb docs: https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_character_set_system

## Solution
Create custom **character_set** rules and copy them into the docker container (see file db/character-set.cnf)

## Result
https://api.eatba.tk/menu/2
<img width="600" alt="Screen Shot 2022-05-14 at 7 16 11 PM" src="https://user-images.githubusercontent.com/49668442/168423465-421e6e57-9f13-42ad-8d88-b00853bc2189.png">


<img width="468" alt="Screen Shot 2022-05-14 at 7 37 23 PM" src="https://user-images.githubusercontent.com/49668442/168423992-22d67de0-c5ae-4460-bc1c-d0186313531b.png">

